### PR TITLE
rename &t query to &theme

### DIFF
--- a/api/index.go
+++ b/api/index.go
@@ -161,7 +161,7 @@ func iconRoute(r *gin.RouterGroup) {
 		ctx.Request.ParseForm()
 		iconParam := ctx.Request.Form.Get("i")
 
-		theme := ctx.Request.Form.Get("t")
+		theme := ctx.Request.Form.Get("theme")
 		if theme == "" {
 			theme = "dark"
 		}


### PR DESCRIPTION
now instead of using &t=light
it uses &theme=light
anyway by the time passes, i might unable to contribute to this project so better know how to work in vercel + golang, xd