### PR TITLE
fix(ci): docker_deploy workflow

### DIFF
--- a/.github/workflows/docker_deploy.yml
+++ b/.github/workflows/docker_deploy.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Build and Push Image
         uses: docker/build-push-action@v6
         with:
-            context: .
-            push: true
-            tags: |
-                ${{ env.DOCKER_IMAGE_NAME }}:latest
-                ghcr.io/${{ env.GITHUB_IMAGE_NAME }}:latest
+          context: .
+          push: true
+          tags: |
+            ${{ env.DOCKER_IMAGE_NAME }}:latest
+            ghcr.io/${{ env.GITHUB_IMAGE_NAME }}:latest

--- a/.github/workflows/docker_deploy.yml
+++ b/.github/workflows/docker_deploy.yml
@@ -7,8 +7,8 @@ on:
 
 env:
   DOCKERHUB_USERNAME: $(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
-  GHCR_REPO: ghcr.io/$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')/skill-icons:latest
-  DOCKERHUB_REPO: $(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')/skill-icons:latest
+  DOCKER_IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }}
+  GHCR_IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build_image:
@@ -24,21 +24,18 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GHCR_TOKEN }}
 
-      - name: Build Docker image for GHCR
-        run: docker build -t ${{ env.GHCR_REPO }} .
+      - name: Log in to docker.io
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Push Docker image to GHCR
-        run: docker push ${{ env.GHCR_REPO }}
-
-      # Fix: Docker Hub not wanting to log in (username and creds are good)
-      # - name: Log in to Docker Hub
-      #   uses: docker/login-action@v3
-      #   with:
-      #     username: ${{ env.DOCKERHUB_USERNAME }}
-      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
-      #
-      # - name: Build Docker image for Docker Hub
-      #   run: docker build -t ${{ env.DOCKERHUB_REPO }} .
-      #
-      # - name: Push Docker image to Docker Hub
-      #   run: docker push ${{ env.DOCKERHUB_REPO }}
+      - name: Build and Push Image
+        uses: docker/build-push-action@v6
+        with:
+            context: .
+            push: true
+            tags: |
+                ${{ env.DOCKER_IMAGE_NAME }}:latest
+                ghcr.io/${{ env.GITHUB_IMAGE_NAME }}:latest


### PR DESCRIPTION
Assuming the Docker Hub username is the same as your GitHub username, and the Docker Hub token has permissions to read & write repositories, this should work as this is pretty much the exact same workflow [I personally use](https://github.com/wdhdev/reminders/blob/main/.github/workflows/docker.yml) in multiple of my repos.

Closes #364 